### PR TITLE
Fix theme toggler icon render on initial load

### DIFF
--- a/hooks/use-mounted.ts
+++ b/hooks/use-mounted.ts
@@ -1,13 +1,12 @@
 'use client';
-import { useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
 
 export function useIsMounted() {
-  const ref = useRef(false);
+  const [mounted, setMounted] = useState(false);
+
   useEffect(() => {
-    ref.current = true;
-    return () => {
-      ref.current = false;
-    };
+    setMounted(true);
   }, []);
-  return ref.current;
+
+  return mounted;
 }


### PR DESCRIPTION
Refactor `useIsMounted` to use `useState` to correctly trigger re-renders and display the theme toggler icon on first page render.

The previous `useIsMounted` implementation used `useRef`, which does not trigger a re-render when its value changes. This caused the `mounted` state to remain `false` during the initial render, preventing the theme toggler icon from being displayed until a subsequent re-render was forced. Switching to `useState` ensures that the component re-renders after mounting, correctly reflecting the `mounted` state.

---
<a href="https://cursor.com/background-agent?bcId=bc-9effcc75-4c5b-44dc-9f02-53eb72eef642">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9effcc75-4c5b-44dc-9f02-53eb72eef642">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

